### PR TITLE
Add 'meson' as requirement

### DIFF
--- a/conan_tests/requirements.txt
+++ b/conan_tests/requirements.txt
@@ -2,3 +2,4 @@ nose>=1.3.7, <1.4.0
 nose_parameterized>=0.5.0, <0.6.0
 mock>=1.3.0, <1.4.0
 WebTest>=2.0.18, <2.1.0
+meson!=0.53


### PR DESCRIPTION
If we are using Meson in these tests, let's install it.

Also, we need to skip meson 0.53, as it is broken for python < 3.5.3 and we don't want to add if/else clauses: https://github.com/mesonbuild/meson/pull/6430