### PR TITLE
Skip CPT test

### DIFF
--- a/conan_tests/external_tools/conan_package_tools_test.py
+++ b/conan_tests/external_tools/conan_package_tools_test.py
@@ -11,7 +11,7 @@ from conans import __version__ as conan_version
 class ConanPackageToolsTest(BaseExeTest):
 
     @unittest.skipIf(sys.version_info[0:2] == (3, 4), "No py3.4")
-    @unittest.skipIf(conan_version < "1.3.0", "Required modern Conan")
+    @unittest.skip("conan-package-tools will never work with non-released Conan versions.")
     def test_package_tools(self):
         run("pip install tabulate")  # only package tools dep
         run("pip install conan_package_tools --no-dependencies")  # Install latest


### PR DESCRIPTION
Conan package tools can't work with a non-released version of Conan so this test was failing from version 1.30 (it was skipped for previous versions: 1.29, 1.28... because of the wrong version comparison).
This test should be probably moved to cpt itself?
