### PR TITLE
Force msys2 subsystem in test

### DIFF
--- a/conan_tests/external_tools/msys2_cygwin_test.py
+++ b/conan_tests/external_tools/msys2_cygwin_test.py
@@ -70,7 +70,7 @@ class ConanBash(ConanFile):
         vs_path = tools.vcvars_dict(self.settings)["PATH"]
         if Version(conan_version) >= Version("1.7.0"):
             vs_path = os.pathsep.join(vs_path)
-        tools.run_in_windows_bash(self, "link", env={"PATH": vs_path})
+        tools.run_in_windows_bash(self, "link", subsystem="msys2", env={"PATH": vs_path})
 
 '''
                 client = TestClient()

--- a/conan_tests/external_tools/msys2_cygwin_test.py
+++ b/conan_tests/external_tools/msys2_cygwin_test.py
@@ -68,8 +68,6 @@ class ConanBash(ConanFile):
 
     def build(self):
         vs_path = tools.vcvars_dict(self.settings)["PATH"]
-        if Version(conan_version) >= Version("1.7.0"):
-            vs_path = os.pathsep.join(vs_path)
         tools.run_in_windows_bash(self, "link", subsystem="msys2", env={"PATH": vs_path})
 
 '''


### PR DESCRIPTION
Force msys2 for test so if another subsystem is installed like WSL it does not detect that instead of msys2.
Also removing an incorrect version check.