### PR TITLE
Do not remove __init__.py

### DIFF
--- a/artifactory_tests/test_runner/launch.sh
+++ b/artifactory_tests/test_runner/launch.sh
@@ -18,6 +18,5 @@ cd conan_sources
 git checkout $CONAN_GIT_TAG
 echo "Let's install Conan as editable"
 pip3 install -e . && pip3 install -r conans/requirements_dev.txt
-rm __init__.py
 echo "Let's run the tests"
 nosetests -w conans -A "artifactory_ready" -v


### PR DESCRIPTION
No that __init__.py has been removed from conan we can skip that step.