### PR TITLE
Install nose as a temporal fix

### DIFF
--- a/artifactory_tests/test_runner/launch.sh
+++ b/artifactory_tests/test_runner/launch.sh
@@ -17,6 +17,6 @@ git clone $CONAN_GIT_REPO conan_sources
 cd conan_sources
 git checkout $CONAN_GIT_TAG
 echo "Let's install Conan as editable"
-pip3 install -e . && pip3 install -r conans/requirements_dev.txt
+pip3 install -e . && pip3 install -r conans/requirements_dev.txt && pip3 install nose
 echo "Let's run the tests"
 nosetests -w conans -A "artifactory_ready" -v

--- a/jenkins/runner.py
+++ b/jenkins/runner.py
@@ -31,6 +31,7 @@ def run_tests(module_path, conan_branch, pyver, tmp_folder, num_cores=3):
         pip_installs.append('pip install requests["security"]')
         pip_installs.append("pip install scons")
         pip_installs.append("pip install pytest")
+        pip_installs.append("pip install nose")
         if pyver != "py27":
             pip_installs.append("pip install meson")
     else:


### PR DESCRIPTION
Before integrating this tests in the Conan Test Suite and migrating to pytest. Temporal fix to pass the preflight installing nose.