### PR TITLE
Update jenkins to run preflight for release/2.X branches

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -20,7 +20,7 @@ try{
     node("LinuxSlave") {
         stage("Testing revisions with Artifactory"){
             checkout scm
-            def arti_versions = (branch != "develop2") ? ["latest", "7.47.12", "7.37.17" , "7.27.10", "7.17.5", "7.2.1", "6.18.1", "6.9.0"] : ["latest"]
+            def arti_versions = (branch != 'develop2' && !branch.startsWith('release/2.')) ? ["latest", "7.47.12", "7.37.17" , "7.27.10", "7.17.5", "7.2.1", "6.18.1", "6.9.0"] : ["latest"]
             for (arti_version in arti_versions){
                 echo "Testing Artifactory ${arti_version} with Conan '${branch}'"
                 withEnv(["CONAN_GIT_TAG=${branch}".toString(), 'CONAN_GIT_REPO=https://github.com/conan-io/conan.git', "ARTIFACTORY_VERSION=${arti_version}"]) {


### PR DESCRIPTION
It was already prepared for develop2 branch, now it will also pick the latest version for release/2.X branches
Closes: https://github.com/conan-io/test/issues/62