### PR TITLE
Use docker compose v2 for tests

### DIFF
--- a/artifactory_tests/run_tests.sh
+++ b/artifactory_tests/run_tests.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export DOCKER_HOST="unix:///var/run/docker.sock"
+
 # Upgrade pip and install dependencies
 pip install --upgrade pip
 pip install docker-compose

--- a/artifactory_tests/run_tests.sh
+++ b/artifactory_tests/run_tests.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-export DOCKER_HOST="unix:///var/run/docker.sock"
-
 pip install --upgrade pip
-pip install docker-compose
-pip install "docker==6.1.3"
 
 function version_gt() { 
     test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"

--- a/artifactory_tests/run_tests.sh
+++ b/artifactory_tests/run_tests.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
-
 set -e
 
 export DOCKER_HOST="unix:///var/run/docker.sock"
 
-# Upgrade pip and install dependencies
 pip install --upgrade pip
 pip install docker-compose
 pip install "docker==6.1.3"
 
-# Function to compare versions
 function version_gt() { 
     test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"
 }
@@ -21,17 +18,17 @@ if version_gt "$min_artifactory_version" "$ARTIFACTORY_VERSION"; then
 fi
 
 echo "Building Docker containers..."
-docker-compose build
-docker-compose pull
+docker compose build
+docker compose pull
 
 echo "Starting Docker containers and running tests..."
-docker-compose up -d
-if docker-compose run test_runner ./launch.sh; then
+docker compose up -d
+if docker compose run test_runner ./launch.sh; then
     echo "Tests passed!"
-    docker-compose down
+    docker compose down
     exit 0
 else
     echo "Tests failed or Artifactory failed to start."
-    docker-compose down
+    docker compose down
     exit 99
 fi

--- a/artifactory_tests/run_tests.sh
+++ b/artifactory_tests/run_tests.sh
@@ -3,16 +3,6 @@ set -e
 
 pip install --upgrade pip
 
-function version_gt() { 
-    test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"
-}
-
-min_artifactory_version="6.9.0"
-if version_gt "$min_artifactory_version" "$ARTIFACTORY_VERSION"; then
-    echo "Artifactory version $ARTIFACTORY_VERSION does not support Conan revisions, exiting successfully."
-    exit 0
-fi
-
 echo "Building Docker containers..."
 docker compose build
 docker compose pull

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -20,13 +20,14 @@ try{
     node("LinuxSlave") {
         stage("Testing revisions with Artifactory"){
             checkout scm
-            // FIXME: uncomment latest when the docker image works again
+            sh 'sudo apt-get update && sudo apt-get install -y docker-compose-plugin'
+            sh 'sudo ln -sf /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose'
             def arti_versions = (branch != 'develop2' && !branch.startsWith('release/2.')) ? ["latest", "7.63.14", "7.59.9", "7.55.13", "7.47.12", "7.37.17" , "7.27.10", "7.17.5", "7.2.1", "6.18.1", "6.9.0"] : ["latest", "7.63.14", "7.59.9", "7.55.13"]
             for (arti_version in arti_versions){
                 echo "Testing Artifactory ${arti_version} with Conan '${branch}'"
                 withEnv(["CONAN_GIT_TAG=${branch}".toString(), 'CONAN_GIT_REPO=https://github.com/conan-io/conan.git', "ARTIFACTORY_VERSION=${arti_version}"]) {
                     withCredentials([string(credentialsId: 'NEW_ART_LICENSE', variable: 'ART_LICENSE')]) {
-                        sh(script: "cd artifactory_tests && ./run_tests.sh")
+                        sh 'cd artifactory_tests && ./run_tests.sh'
                     }
                 }
             }
@@ -40,7 +41,6 @@ catch(e){
     throw e
 }
 
-// these tests are not prepared for Conan 2.0, omit them
 if (branch != 'develop2' && !branch.startsWith('release/2.'))
 {
     def builders = [:]
@@ -99,7 +99,6 @@ if (branch != 'develop2' && !branch.startsWith('release/2.'))
         throw e
     }
 }
-
 
 def subject = "SUCCESS ${env.JOB_NAME}! Another day with a green ${branch}!"
 def summary = "${subject} (${env.BUILD_URL})"

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -21,7 +21,6 @@ try{
         stage("Testing revisions with Artifactory"){
             checkout scm
             sh 'sudo apt-get update && sudo apt-get install -y docker-compose-plugin'
-            sh 'sudo ln -sf /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose'
             def arti_versions = (branch != 'develop2' && !branch.startsWith('release/2.')) ? ["latest", "7.63.14", "7.59.9", "7.55.13", "7.47.12", "7.37.17" , "7.27.10", "7.17.5", "7.2.1", "6.18.1", "6.9.0"] : ["latest", "7.63.14", "7.59.9", "7.55.13"]
             for (arti_version in arti_versions){
                 echo "Testing Artifactory ${arti_version} with Conan '${branch}'"


### PR DESCRIPTION
Use Docker Compose v2 (`docker compose`) and remove legacy Python install. This fixes the invalid `http+docker://` URL error in preflight tests.